### PR TITLE
networking.rst: tcp_hdr restrictions pre 3.11-rc2

### DIFF
--- a/Documentation/teaching/labs/networking.rst
+++ b/Documentation/teaching/labs/networking.rst
@@ -856,7 +856,8 @@ Registering/unregistering a hook is done using the functions defined in
 
 .. attention::
 
-  There are some restrictions related to the use of header extraction functions
+  Prior to version 3.11-rc2 of the Linux kernel,
+  there are some restrictions related to the use of header extraction functions
   from a :c:type:`struct sk_buff` structure set as a parameter in a netfilter
   hook. While the IP header can be obtained each time using :c:func:`ip_hdr`,
   the TCP and UDP headers can be obtained with :c:func:`tcp_hdr` and


### PR DESCRIPTION
at commit 21d1196a35f5686c4323e42a62fdb4b23b0ab4a3

```
skb->transport_header = skb->network_header + iph->ihl*4;
```

was added to `net/ipv4/ip_input.c` and now at NF_IP_LOCAL_IN hooks, `tcp_hdr` or `udp_hdr` maye be used too.